### PR TITLE
更改Shizuku激活文件储存地址

### DIFF
--- a/src/AutumnBox.Extensions.Standard.Shared/Extensions/Poweron/EShizukuActivator.cs
+++ b/src/AutumnBox.Extensions.Standard.Shared/Extensions/Poweron/EShizukuActivator.cs
@@ -21,7 +21,7 @@ namespace AutumnBox.CoreModules.Extensions.Poweron
     internal class EShizukuActivator : LeafExtensionBase
     {
         private const string PKG_NAME = "moe.shizuku.privileged.api";
-        private const string SH_PATH = "/sdcard/Android/data/moe.shizuku.privileged.api/files/start.sh";
+        private const string SH_PATH = "/sdcard/Android/data/moe.shizuku.privileged.api/start.sh";
      
         [LMain]
 #pragma warning disable CA1822 // 将成员标记为 static


### PR DESCRIPTION
在新版本Shizuku中，激活文件start.sh更换了地方，所以需要修改
(其实更建议通过adb tcpip 5555来进行无限调试)